### PR TITLE
Add logback support, separating dev from prod logging level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .classpath
 .project
 .springBeans
+*.log

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ The KeyCloak parameters are configured using environment variables inside the `a
 docker run --name auth --restart=always -d -e KEYCLOAK_URL=http://localhost:9090/auth -e KEYCLOAK_REALM=test -e KEYCLOAK_CLIENT_ID=test -e health/auth
 ```
 
-Logging can be also configured using `LOGGING_FILE` and sharing a volume (for [ELK](https://www.elastic.co/elk-stack) processing):
+Logging can be also configured using `LOGGING_FOLDER` and sharing a volume (for [ELK](https://www.elastic.co/elk-stack) processing). The level of the logging can be configured with `LOGGING_MODE` (dev|prod):
 ```
-docker run --name auth --restart=always -d -v /home/docker/log/test:/log/test -e KEYCLOAK_URL=http://localhost:9090/auth -e KEYCLOAK_REALM=test -e KEYCLOAK_CLIENT_ID=test -e LOGGING_FILE=/log/test/test.log health/auth
+docker run --name auth --restart=always -d -v /home/docker/log/test:/log/test -e KEYCLOAK_URL=http://localhost:9090/auth -e KEYCLOAK_REALM=test -e KEYCLOAK_CLIENT_ID=test -e LOGGING_FOLDER=/log/test -e LOGGING_MODE=dev health/auth
 ```
 
 # License

--- a/src/main/java/net/atos/ari/auth/controller/AuthController.java
+++ b/src/main/java/net/atos/ari/auth/controller/AuthController.java
@@ -39,6 +39,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 import org.springframework.http.HttpHeaders;
 
@@ -65,7 +66,7 @@ public class AuthController {
 	
 	@ApiOperation(value = "Provide the user preferred name given the token")
 	@GetMapping("/user")
-	public String user(@RequestHeader(HttpHeaders.AUTHORIZATION) String token) 
+	public String user(@ApiParam(value="Bearer <token>") @RequestHeader(HttpHeaders.AUTHORIZATION) String token) 
 			throws NotAuthorizedException {
 		log.info("Get User info");
 		return authService.user(token);

--- a/src/main/java/net/atos/ari/auth/service/AuthService.java
+++ b/src/main/java/net/atos/ari/auth/service/AuthService.java
@@ -59,6 +59,7 @@ public class AuthService implements Service {
     private String keycloak_client_id;
 	
 	RestTemplate restTemplate = new RestTemplate();
+	private String BEARER = "BEARER ";
 
 	@Override
 	public AccessTokenResponse login(KeyCloakUser user) throws NotAuthorizedException {
@@ -87,8 +88,10 @@ public class AuthService implements Service {
 	@Override
 	public String user(String authToken) throws NotAuthorizedException {
         
-        HttpHeaders headers = new HttpHeaders();
-		headers.set("Authorization", "Bearer " + authToken);
+        if (authToken.toUpperCase().startsWith(BEARER) == false) 
+            throw new NotAuthorizedException("Invalid OAuth Header. Missing Bearer prefix");        HttpHeaders headers = new HttpHeaders();
+
+            headers.set("Authorization", authToken);
 		HttpEntity<String> entity = new HttpEntity<String>(headers);
 		
 		ResponseEntity<AccessToken> response = restTemplate.exchange(keycloak_url + "/realms/" + 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,14 +6,9 @@ keycloak:
     realm: ${KEYCLOAK_REALM:test}
     client_id: ${KEYCLOAK_CLIENT_ID:test}
     
-logging:
-    level:
-      root: info*
-    pattern:
-      console: "%d [%thread] %-5level %logger %M : %msg%n*"
-    file: ${LOGGING_FILE:./positive.log}
-    
 spring:
+    profiles:
+      active: ${LOGGING_MODE:dev}
     jackson:
       serialization:
         INDENT_OUTPUT: true

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<property name="LOG_DIR" value="${LOGGING_FOLDER:-logs}" />
+	<property name="LOG_FILE" value="auth" />
+
+	<appender name="STDOUT"
+		class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>
+				%d{HH:mm:ss.SSS} %-5level [%thread] %C{0}.%M[%L] - %msg%n
+			</pattern>
+		</encoder>
+	</appender>
+
+	<appender name="SAVE-TO-FILE"
+		class="ch.qos.logback.core.rolling.RollingFileAppender">
+		<file>${LOG_DIR}/${LOG_FILE}.log</file>
+		<encoder
+			class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+			<Pattern>
+				%d{dd-MM-yyyy HH:mm:ss.SSS} %-5level [%thread] %logger{36}.%M - %msg%n
+			</Pattern>
+		</encoder>
+		<rollingPolicy
+			class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<!-- rollover daily & on size -->
+			<maxFileSize>10MB</maxFileSize>
+			<fileNamePattern>
+				${LOG_DIR}/archived/${LOG_FILE}_%d{dd-MM-yyyy}_%i.log
+			</fileNamePattern>
+			<maxHistory>10</maxHistory>
+			<totalSizeCap>100MB</totalSizeCap>
+		</rollingPolicy>
+	</appender>
+
+	<springProfile name="dev">
+		<root level="debug">
+			<appender-ref ref="STDOUT" />
+			<appender-ref ref="SAVE-TO-FILE" />
+		</root>
+	</springProfile>
+
+	<springProfile name="prod">
+		<root level="info">
+			<appender-ref ref="SAVE-TO-FILE" />
+		</root>
+	</springProfile>
+
+</configuration>


### PR DESCRIPTION
## Proposed Changes

  - Add a new profile dev/prod for the logging level
  - Add the logback.xml file with the proper level
  - The "Bearer" string must be included at the beginning of the header in user function
  - Need LOGGING_MODE and LOGGING_FOLDER environment variables

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
The user function does not need the "Bearer" authorization string
Issue Number: #1 
Fixes #6, #7 

## What is the new behavior?
The logging level can be configured with spring profiles dev and prod and now "Bearer" string is needed in the user function.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
