### PR TITLE
bugfix: Put the correct .travis folder in the yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 script:
   - mvn clean compile
   - if [ "$TRAVIS_BRANCH" = "master" ]; then mvn clean test; mvn package -Dmaven.test.skip=true; mvn -s .travis/settings.xml sonar:sonar; fi
-  - if [ "$TRAVIS_BRANCH" = "release" ]; then chmod +x .travis/prepare.sh && ./travis/prepare.sh; mvn -s .travis/settings.xml -B release:clean release:prepare; git push --tags; mvn -s .travis/settings.xml -B release:perform; mvn generate-sources; chmod +x ./push.sh && ./push.sh; fi
+  - if [ "$TRAVIS_BRANCH" = "release" ]; then chmod +x .travis/prepare.sh && .travis/prepare.sh; mvn -s .travis/settings.xml -B release:clean release:prepare; git push --tags; mvn -s .travis/settings.xml -B release:perform; mvn generate-sources; chmod +x .travis/push.sh && .travis/push.sh; fi
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
## Proposed Changes

  - Modify travis yml to put the correct folder for the scripts prepare and push

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
Travis fails when executing the release of the artefact

## What is the new behavior?

- Put .travis folder to execute the scripts

## Does this introduce a breaking change?

- [ ] Yes
- [x] No