### PR TITLE
Exclude .travis folder during the prepare stage and git add only the …

### DIFF
--- a/.travis/push.sh
+++ b/.travis/push.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 # Commit the CHANGELOG modifications and new versioning
-git commit -am 'Automatic release increment and changelog generation. Travis build $TRAVIS_BUILD_NUMBER pushed [skip ci]'
+git add CHANGELOG.md pom.xml
+git commit -m 'Automatic release increment and changelog generation [skip ci]'
 
 # Push the modifications into develop
 git push origin HEAD:master

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,8 @@
 						<goals>deploy</goals>
 						<checkModificationExcludes>
 							<checkModificationExclude>CHANGELOG.md</checkModificationExclude>
+							<checkModificationExclude>.travis/prepare.sh</checkModificationExclude>
+							<checkModificationExclude>.travis/push.sh</checkModificationExclude>
 						</checkModificationExcludes>
 					</configuration>
 					<dependencies>


### PR DESCRIPTION
…CHANGELOG and the pom files

## Proposed Changes

  - Exclude .travis folder during the prepare stage
  - Git add only CHANGELOG.md and pom.xml
  - Modify the commit message

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
There is no prepare:release because the plugin detects there are changes not staged

## What is the new behavior?

- Exclude the .travis folder from the git identification in maven
- Git add only the needed files

## Does this introduce a breaking change?

- [ ] Yes
- [x] No