### PR TITLE
Remove Gson dependency to comply with Single Responsibility principle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,12 +92,6 @@
 		</dependency>
 		<!-- Keycloak end -->
 
-		<!-- Gson -->
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-		</dependency>
-
 		<!-- Lombok -->
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/src/main/java/net/atos/ari/auth/model/KeycloakUser.java
+++ b/src/main/java/net/atos/ari/auth/model/KeycloakUser.java
@@ -23,8 +23,6 @@
 
 package net.atos.ari.auth.model;
 
-import com.google.gson.Gson;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -37,9 +35,4 @@ import lombok.NoArgsConstructor;
 public class KeycloakUser {
 	private String username;
 	private String password;
-
-	@Override
-	public String toString() {
-		return new Gson().toJson(this, KeycloakUser.class);
-	} 
 }


### PR DESCRIPTION
## Proposed Changes

  - Remove Gson dependecy from maven pom
  - Remove overriding function toString from KeycloakUser class to convert the object to JSON

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [x] Code format / lint
- [x] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?

Currently the KeycloakUser class overrides toString function to convert the data object to JSON.

Fixes #12 

## What is the new behavior?

- Function toString does not convert to JSON to comply the Single Responsibility principle

## Does this introduce a breaking change?

- [ ] Yes
- [x] No