### PR TITLE
Upgrade to java 11 and fix the issue with SonarQube 7.9.1 LTS with incorrect sonar scanner maven plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: java
 
-jdk: openjdk8
-
 sudo: false # faster builds
 
 cache:

--- a/.travis/settings.xml
+++ b/.travis/settings.xml
@@ -19,34 +19,11 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<!--
- | This is the configuration file for Maven. It can be specified at two levels:
- |
- |  1. User Level. This settings.xml file provides configuration for a single user, 
- |                 and is normally provided in ${user.home}/.m2/settings.xml.
- |
- |                 NOTE: This location can be overridden with the CLI option:
- |
- |                 -s /path/to/user/settings.xml
- |
- |  2. Global Level. This settings.xml file provides configuration for all Maven
- |                 users on a machine (assuming they're all using the same Maven
- |                 installation). It's normally provided in 
- |                 ${maven.home}/conf/settings.xml.
- |
- |                 NOTE: This location can be overridden with the CLI option:
- |
- |                 -gs /path/to/global/settings.xml
- |
- | The sections in this sample file are intended to give you a running start at
- | getting the most out of your Maven installation. Where appropriate, the default
- | values (values used when the setting is not specified) are provided.
- |
- |-->
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" 
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
   <pluginGroups>
+	<pluginGroup>org.sonarsource.scanner.maven</pluginGroup>
   </pluginGroups>
 
   <proxies>


### PR DESCRIPTION
## Proposed Changes

  - Remove the usage of jdk8 from `.travis.yml` 
  - Modify `.travis/settings.xml` to use the last version of sonar scanner maven

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?

Fixes #28 

## What is the new behavior?

- Upgrade to java 11
- Sonar analysis is working with SonarQube 7.9.1 LTS

## Does this introduce a breaking change?

- [ ] Yes
- [x] No